### PR TITLE
Coffeee consumed chart

### DIFF
--- a/src/resources/machine-service.ts
+++ b/src/resources/machine-service.ts
@@ -10,7 +10,7 @@ export class MachineService extends Service {
         return this.http.fetch(MachineService.ENDPOINT);
     }
 
-    public getCoffeeCount(machineId: string): Promise<Response> {
+    public getCoffees(machineId: string): Promise<Response> {
         const resource = `${MachineService.ENDPOINT}/${machineId}/coffee`;
         return this.http.fetch(resource);
     }

--- a/src/routes/coffee-counter/coffee-counter.html
+++ b/src/routes/coffee-counter/coffee-counter.html
@@ -1,24 +1,37 @@
 <template>
-    <h1>${heading}</h1>
-    <p>Welcome to the coffee counter!</p>
+    <h2>Consumed coffee</h2>
+    <p>Select a machine and a range of time to see how much coffee was produced</p>
 
-    <button click.delegate="getAllCoffees()">Get all coffees</button>
-    <p if.bind="allCoffees">${allCoffees}</p>
-    <p></p>
-    <button click.delegate="getAllMachines()">Get all machines</button>
-    <p if.bind="allCoffeesOfSpecificMachine">${allCoffeesOfSpecificMachine}</p>
-    <template if.bind="machines.length===0">
-        <p>No machines found.</p>
-    </template>
-    <template if.bind="machines && machines.length!==0">
-        <p>To see the number of produced coffees by a specific machine, click on one:</p>
-        <ul class="list-group">
-            <li repeat.for="machine of machines" click.delegate="getAllCoffeesOfMachine(machine.id)"
-                class="list-group-item">
+    <div class="form-group row">
+        <label for="chartMachineSelect" class="col-sm-2 col-form-label">Machine: </label>
+        <div class="col-sm-4">
+            <select class="form-control" 
+                    id="chartMachineSelect" 
+                    value.bind="selectedChartMachine" 
+                    change.delegate="onSelectedChartMachineChanged(selectedChartMachine)" 
+            >
+                <option model.bind="null">All machines</option>
+                <option repeat.for="machine of machines" model.bind="machine.id">
                 ${machine.name}
-            </li>
-        </ul>
-    </template>
+                </option>
+            </select>
+        </div>
+        <label for="chartTimeModeSelect" class="col-sm-2 col-form-label">timerange: </label>
+        <div class="col-sm-4">
+            <select class="form-control" 
+                    id="chartTimeModeSelect" 
+                    value.bind="selectedChartTimeMode" 
+                    change.delegate="onSelectedChartTimeModeChange(selectedChartTimeMode)" 
+            >
+                <option repeat.for="mode of chartTimeModes" model.bind="mode.value">
+                ${mode.text}
+                </option>
+            </select>
+        </div>
+    </div>
+    <div class="alert alert-info" role="alert">
+        ${consumptionMessage}<strong>${producedInSelection}</strong>
+    </div>
     <div>
         <canvas ref="chartEl" style="width: 100%; height:400px;"></canvas>
     </div>

--- a/src/routes/coffee-counter/coffee-counter.html
+++ b/src/routes/coffee-counter/coffee-counter.html
@@ -19,4 +19,7 @@
             </li>
         </ul>
     </template>
+    <div>
+        <canvas ref="chartEl" style="width: 100%; height:400px;"></canvas>
+    </div>
 </template>

--- a/src/routes/coffee-counter/coffee-counter.ts
+++ b/src/routes/coffee-counter/coffee-counter.ts
@@ -2,6 +2,9 @@ import { autoinject } from 'aurelia-framework';
 import { CoffeeService } from 'resources/coffee-service';
 import { MachineService } from 'resources/machine-service';
 import { MeasurementService } from 'resources/measurement-service';
+import * as Chart from 'chart.js';
+import * as moment from 'moment';
+import { labeledStatement } from '@babel/types';
 
 @autoinject
 export class CoffeeCounter {
@@ -10,10 +13,65 @@ export class CoffeeCounter {
     private allCoffeesOfSpecificMachine: string;
     private machines;
     private points = [];
+    private chartEl: HTMLCanvasElement;
+    private chart: Chart;
+    private data: Chart.ChartData;
 
     constructor(private coffeeService: CoffeeService,
-                private machineService: MachineService,
-                private measurementService: MeasurementService) { }
+        private machineService: MachineService,
+        private measurementService: MeasurementService) {
+        this.coffeeService.getAll().then(response => response.json())
+            .then(coffees => {
+                this.data = this.generateData(coffees);
+            });
+    }
+
+    public generateData(coffees) {
+        const today = moment();
+        const dateLabels = [];
+        const coffeeCount = Array(7).fill(0);
+        const aWeekAgo = moment(today).subtract(6, "days");
+        for (const m = moment(aWeekAgo); m.isSameOrBefore(today); m.add(1, 'days')) {
+            dateLabels.push(m.format('DD.M'));
+        }
+        coffees.forEach(c => {
+            const daysDifference = moment(c.createdAt).diff(today, 'days');
+            if (daysDifference >= -6) {
+                coffeeCount[daysDifference + 6] = coffeeCount[daysDifference + 6] + 1;
+            }
+        });
+        return {
+            labels: dateLabels,
+            datasets: [{
+                label: 'Coffees consumed',
+                data: coffeeCount,
+            }],
+        };
+
+    }
+
+    public attached() {
+        this.chart = new Chart(this.chartEl, {
+            type: 'bar',
+            options: {
+                hover: {
+                    mode: 'label',
+                },
+                spanGaps: false,
+                scales: {
+                    xAxes: [{
+                        display: true,
+                    }],
+                },
+                plugins: {
+                    colorschemes: {
+                        scheme: 'office.Essential6',
+                    },
+                },
+            },
+            data: this.data,
+        });
+    }
 
     private getAllCoffees(): void {
         this.coffeeService.getAll()

--- a/src/routes/coffee-counter/coffee-counter.ts
+++ b/src/routes/coffee-counter/coffee-counter.ts
@@ -4,45 +4,113 @@ import { MachineService } from 'resources/machine-service';
 import { MeasurementService } from 'resources/measurement-service';
 import * as Chart from 'chart.js';
 import * as moment from 'moment';
-import { labeledStatement } from '@babel/types';
 
+type ChartTimeMode = 'day' | 'week' | 'month' | 'year';
 @autoinject
 export class CoffeeCounter {
-    private heading = 'Coffee Counter';
-    private allCoffees: string;
-    private allCoffeesOfSpecificMachine: string;
+    private selectedChartMachine: null | string = null;
     private machines;
-    private points = [];
     private chartEl: HTMLCanvasElement;
     private chart: Chart;
     private data: Chart.ChartData;
+    private producedInSelection = 0;
+    private selectedChartTimeMode: ChartTimeMode = 'week';
+    private chartTimeModes = [
+        { value: 'day', text: 'last 24 hours' },
+        { value: 'week', text: 'last 7 days' },
+        { value: 'month', text: 'last month' },
+        { value: 'year', text: 'last year' },
+    ];
+
+    public get consumptionMessage() {
+        return `Coffees produced in the ${this.currentModeText} by ${this.currentMachineText}: `;
+    }
+
+    public get currentModeText() {
+        return this.chartTimeModes.find(m => m.value === this.selectedChartTimeMode).text;
+    }
+
+    public get currentMachineText() {
+        return this.selectedChartMachine == null ? 'all machines' :
+            this.machines.find(m => m.id === this.selectedChartMachine).name;
+    }
 
     constructor(private coffeeService: CoffeeService,
         private machineService: MachineService,
         private measurementService: MeasurementService) {
-        this.coffeeService.getAll().then(response => response.json())
+        this.refreshChart();
+        this.getAllMachines();
+    }
+
+    public onSelectedChartTimeModeChange(mode: ChartTimeMode) {
+        this.selectedChartTimeMode = mode;
+        this.refreshChart();
+    }
+
+    public onSelectedChartMachineChanged(machineId: string | null) {
+        this.selectedChartMachine = machineId;
+        this.refreshChart();
+    }
+
+    public refreshChart() {
+        const currentChartTimeMode = this.selectedChartTimeMode;
+        this.getCoffeesPromise()
+            .then(response => response.json())
             .then(coffees => {
-                this.data = this.generateData(coffees);
+                this.data = this.generateChartData(coffees, currentChartTimeMode);
+                if (this.chart) {
+                    this.chart.data = this.data;
+                    this.chart.update();
+                }
             });
     }
 
-    public generateData(coffees) {
+    public generateChartData(coffees, mode: ChartTimeMode = 'week'): Chart.ChartData {
         const today = moment();
         const dateLabels = [];
-        const coffeeCount = Array(7).fill(0);
-        const aWeekAgo = moment(today).subtract(6, "days");
-        for (const m = moment(aWeekAgo); m.isSameOrBefore(today); m.add(1, 'days')) {
-            dateLabels.push(m.format('DD.M'));
+        let timeUnit: moment.unitOfTime.DurationConstructor = 'days';
+        let timeDifference = 6;
+        let timeFormat = 'DD.M';
+        switch (mode) {
+            case 'day':
+                timeUnit = 'hours';
+                timeDifference = 23;
+                timeFormat = 'HH';
+                break;
+            case 'week':
+                timeUnit = 'days';
+                timeDifference = 6;
+                timeFormat = 'ddd';
+                break;
+            case 'month':
+                timeUnit = 'days';
+                timeDifference = 50;
+                timeFormat = 'DD.M';
+                break;
+            case 'year':
+                timeUnit = 'month';
+                timeDifference = 11;
+                timeFormat = 'MMM';
+                break;
+        }
+        const coffeeCount = Array(timeDifference + 1).fill(0);
+
+        const aWeekAgo = moment(today).subtract(timeDifference, timeUnit);
+        for (const m = moment(aWeekAgo); m.isSameOrBefore(today); m.add(1, timeUnit)) {
+            dateLabels.push(m.format(timeFormat));
         }
         coffees.forEach(c => {
-            const daysDifference = moment(c.createdAt).diff(today, 'days');
-            if (daysDifference >= -6) {
-                coffeeCount[daysDifference + 6] = coffeeCount[daysDifference + 6] + 1;
+            const daysDifference = moment(c.createdAt).diff(today, timeUnit);
+            if (daysDifference >= -timeDifference) {
+                coffeeCount[daysDifference + timeDifference] = coffeeCount[daysDifference + timeDifference] + 1;
             }
         });
+        this.producedInSelection = coffeeCount.reduce((sum, curr) => (sum + curr), 0);
         return {
             labels: dateLabels,
             datasets: [{
+                backgroundColor: 'rgb(255, 99, 132)',
+                borderColor: 'rgb(255, 99, 132)',
                 label: 'Coffees consumed',
                 data: coffeeCount,
             }],
@@ -61,7 +129,24 @@ export class CoffeeCounter {
                 scales: {
                     xAxes: [{
                         display: true,
+                        ticks: {
+                            min: 0,
+                            stepSize: 1,
+                        },
                     }],
+                    yAxes: [
+                        {
+                            // typing seems to be wrong here,
+                            // thus we need to cast it to any to ignore it
+                            // it seems to work as appropriate,
+                            // we only get integer ticks with it
+                            ticks: {
+                                beginAtZero: true,
+                                precision: 0,
+                                min: 0,
+                            } as any,
+                        },
+                    ],
                 },
                 plugins: {
                     colorschemes: {
@@ -73,24 +158,11 @@ export class CoffeeCounter {
         });
     }
 
-    private getAllCoffees(): void {
-        this.coffeeService.getAll()
-            .then(response => response.json())
-            .then(listOfCoffees => {
-                this.allCoffees = 'All coffees: ' + Object.keys(listOfCoffees).length;
-                console.log('Returned list of coffees:' + listOfCoffees);
-            })
-            .catch(error => {
-                console.log('Error getting list of coffees!');
-            });
-    }
-
-    private getAllCoffeesOfMachine(machineId): void {
-        this.machineService.getCoffeeCount(machineId)
-            .then(response => response.text())
-            .then(text => {
-                this.allCoffeesOfSpecificMachine = 'All coffees of machine ' + machineId + ': ' + parseInt(text);
-            });
+    private getCoffeesPromise() {
+        if (this.selectedChartMachine == null) {
+            return this.coffeeService.getAll();
+        }
+        return this.machineService.getCoffees(this.selectedChartMachine);
     }
 
     private getAllMachines(): void {


### PR DESCRIPTION
Improves the main coffee view by adding a chart.

Before:  ![old](https://user-images.githubusercontent.com/14406883/70376541-2d623680-190a-11ea-8b30-ec2f6cee68f2.png)

After: 
![charts](https://user-images.githubusercontent.com/14406883/70376554-423eca00-190a-11ea-93cc-a997fddb43b6.png)

You can select the machine (or all machines), as well as a range of time (last 24 hours, last 7 days, last month, last year)

Requires the backend pull request https://github.com/ASE2019-red/thingy-api-red/pull/28
